### PR TITLE
Enabled custom connect queries for socket.io.  Needed for token auth

### DIFF
--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -4,9 +4,9 @@
    * AMD module shim
    * @param {Function} fn The callback function
    */
-  var def = (typeof define === "undefined") ? function (deps, fn) {
+  var def = (typeof define === 'undefined') ? function (deps, fn) {
     var res = fn(can, can.Model);
-    if (typeof exports === "undefined" && typeof window !== "undefined") {
+    if (typeof exports === 'undefined' && typeof window !== 'undefined') {
       can.Feathers = res;
     } else {
       module.exports = res;
@@ -55,8 +55,8 @@
                   model[modelEvent]();
                 }
               }
-            }
-          }
+            };
+          };
 
           this.connect.done(function(socket) {
             socket.on(service + ' created', makeHandler('create'));
@@ -128,7 +128,7 @@
         }, {});
       },
 
-      connect: function(options) {
+      connect: function(options, queryObj) {
         options = options || {};
 
         // Load the Socket library (SocketIO or Primus) into a Script tag
@@ -141,7 +141,12 @@
           var resolve = function () {
             // Connect to the socket via the library given
             var provider = options.type === 'primus' ? Primus : io;
-            dfd.resolve(provider.connect(options.host));
+            // Use the query object, if provided.
+            if (queryObj) {
+              dfd.resolve(provider.connect(options.host, queryObj));
+            } else {
+              dfd.resolve(provider.connect(options.host));
+            }
           };
 
           script.setAttribute('type', 'text/javascript');

--- a/readme.md
+++ b/readme.md
@@ -15,13 +15,21 @@ Once set up you have to connect to the Feathers server:
 ```js
 // connects to the current host via SocketIO
 can.Feathers.connect();
+
 // connects to todos.feathersjs.com
 can.Feathers.connect('http://todos.feathersjs.com');
+
+// connects to current host with custom token auth.
+can.Feathers.connect('',{
+  query: 'token=<custom-token-here>'
+});
+
 // connect to my.app.com using Primus
 can.Feathers.connect({
   host: 'http://my.app',
   type: 'primus'
 });
+
 ```
 
 To create a model you can use the shorthand `can.Feathers.model`:


### PR DESCRIPTION
Added a second parameter for using a custom query with socket.io.  This is useful and required for using token authentication.

``` js
var token = $.cookie('feathers-token');
can.Feathers.connect('',{
  query: 'token=' + token
});
```

Although I do plan to dive into Primus soon, I haven't taken the time to figure out token auth for Primus, so this will probably only work for socket.io unless they have the same connect() api.

Here's an example of how this would be used to setup socket.io auth on the server side:

``` js
app.configure(feathers.socketio(function(io) {

    io.set('authorization', function (handshake, callback) {

        if (handshake.query.token) {

            // where decodeToken can be any script for decoding a token
            decodeToken(handshake.query.token, function(err, data){
                if (err) {
                    console.log(err);
                } else if (data.email) {
                    handshake.feathers = {
                        user: data
                    };
                    callback(null, true);
                }
            });

        } else {
        callback(null, false);
        }
    });

}));
```
