### PR TITLE
Setting up params on {query:params} for consistency with REST.

### DIFF
--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -97,6 +97,9 @@
       },
 
       findAll: function (params) {
+        if (params) {
+          params = {query:params};
+        }
         return this.send('find', params || {});
       },
 


### PR DESCRIPTION
This pull request modifies findAll to match the behavior of a standard CanJS model, making it possible to swap a standard model out for a feathers model without having to rewrite other parts of an app.

Currently, in FeathersJS, the query from requests coming in over the REST interface gets set up on params.query, thus CanJS findAll request params get passed on params.query.  To be compatible, params should be passed inside a query: {query:params}
