### PR TITLE
Don't allow create if the event is already in the model store.

### DIFF
--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -48,11 +48,15 @@
               } else if(self._locks[id] !== ev) {
                 // Mapping from CanJS to Feathers event name
                 var modelEvent = ev === 'remove' ? 'destroyed' : ev + 'd';
-                // Trigger the event from the service as a model event
-                var model = self.model(data);
 
-                if(model[modelEvent]) {
-                  model[modelEvent]();
+                // Don't trigger the create event on the model if it's
+                // already in the model store, but still trigger other events.
+                if (!(ev =='create' && self.store[id])) {
+                  // Trigger the event from the service as a model event
+                  var model = self.model(data);
+                  if(model[modelEvent]) {
+                    model[modelEvent]();
+                  }
                 }
               }
             };


### PR DESCRIPTION
When creating and updating just after 'created', like this:

``` js
'{Transaction} created':function(Transaction, ev, txn){

    // Update the balance.
    this.updateBalance(txn);

    // Save the model
    txn.save();
},
```

the create event can still run twice on the computer on which the txn was created, resulting in duplicate copies.

This PR checks the model store before creating to avoid possible duplicates that the _locks don't catch.
