### PR TITLE
Reversing PR #2 for Feathers 1.0

### DIFF
--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -94,9 +94,6 @@
       },
 
       findAll: function (params) {
-        if (params) {
-          params = {query:params};
-        }
         return this.send('find', params || {});
       },
 


### PR DESCRIPTION
I noticed that while using canjs-feathers with feathers version 1.0.0-pre.5 that I'm getting an extra level of "query" inside params.  Here's console output

``` js
// Notice { query: { query: {} },
{ params: { query: { query: {} }, user: { name: 'David' } },
  callback: [Function],
  method: 'find',
  type: 'before' }
```

This PR is to reverse #2, which is the source of the extra query, since feathers takes care of this, now.
