### PR TITLE
Removed script auto-load.  Added can.Feathers.disconnect().

### DIFF
--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -1,3 +1,5 @@
+'use strict';
+
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         define(['can/util/library', 'can/model'], factory);
@@ -10,6 +12,8 @@
     var stripSlashes = function (name) {
       return name.replace(/^\/|\/$/g, '');
     };
+
+    var internalSocket;
 
     var socketTypes = {
       primus: 'primus/primus.js',
@@ -56,6 +60,7 @@
           };
 
           this.connect.done(function(socket) {
+            internalSocket = socket;
             socket.on(resource + ' created', makeHandler('create'));
             socket.on(resource + ' updated', makeHandler('update'));
             socket.on(resource + ' removed', makeHandler('remove'));
@@ -125,6 +130,10 @@
         }, {});
       },
 
+      disconnect: function(){
+        return internalSocket.disconnect();
+      },
+
       connect: function(options, queryObj) {
         options = options || {};
 
@@ -133,7 +142,7 @@
 
         // We should only connect once
         if(dfd.state() !== 'resolved') {
-          var script = document.createElement('script');
+          // var script = document.createElement('script');
           // Resolves the Deferred when the script is loaded
           var resolve = function () {
             // Connect to the socket via the library given
@@ -146,19 +155,7 @@
             }
           };
 
-          script.setAttribute('type', 'text/javascript');
-          script.setAttribute('src', (options.host || '') +
-            '/' + socketTypes[options.type || 'socketio']);
-
-          script.onload = resolve;
-
-          script.onreadystatechange = function () {
-            if (this.readyState === 'complete') {
-              resolve();
-            }
-          };
-
-          document.body.appendChild(script);
+          resolve();
         }
 
         return dfd;


### PR DESCRIPTION
This stops canjs-feathers from automatically loading the socket library script, thus making it necessary to have a previous, separate socket.io script before loading canjs-feathers.

Also, I'd like to be able to disconnect the socket and reconnect it with an auth token upon login. So this...

``` js
// Setting up a socket with access to public-only data.
can.Feathers.connect('', {transports: ['websocket', 'xhr-polling'] });
```

is later followed, upon login, by this:

``` js
can.Feathers.disconnect();
// Setting up a socket with authenticated access.
can.Feathers.connect('', {query: 'token=' + localStorage.getItem('featherstoken'), transports: ['websocket', 'xhr-polling'] });

```

I added a couple of lines to give access to socket.disconnect() by way of can.Feathers.disconnect().  It does the job, but quite permanently.  It will take some more work to make it possible to reconnect the socket once disconnected.
